### PR TITLE
refactor: update color formatting for warnings in formatter and tests

### DIFF
--- a/pyward/format/formatter.py
+++ b/pyward/format/formatter.py
@@ -1,15 +1,17 @@
-from colorama import Fore
+from colorama import Fore, Back, Style
 
 
 def format_security_warning(message: str, lineno: int, cve_id: str = '') -> str:
+    cve_format = f"{Fore.RED}[{cve_id}]{Style.RESET_ALL}" if cve_id != '' else ''
     return (
-        f"{Fore.RED}[Security]{Fore.RESET}"
-        f"{'[' + cve_id + ']' if cve_id != '' else ''} Line {lineno}: {message}"
+        f"{Fore.WHITE}{Back.RED}[Security]{Style.RESET_ALL}"
+        f"{cve_format}"
+        f" Line {lineno}: {message}"
     )
 
 
 def format_optimization_warning(message: str, lineno: int) -> str:
     return (
-        f"{Fore.YELLOW}[Optimization]{Fore.RESET} "
+        f"{Fore.WHITE}{Back.YELLOW}[Optimization]{Style.RESET_ALL} "
         f"Line {lineno}: {message}"
     )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,15 +1,16 @@
 import pytest
-from colorama import Fore
+from colorama import Fore, Back, Style
 
 from pyward.format.formatter import (
     format_security_warning,
     format_optimization_warning,
 )
 
-OPTIMIZATION_COLOR = Fore.YELLOW
-SECURITY_COLOR = Fore.RED
-OPTIMIZATION_LABEL = f"{OPTIMIZATION_COLOR}[Optimization]{Fore.RESET}"
-SECURITY_LABEL = f"{SECURITY_COLOR}[Security]{Fore.RESET}"
+OPTIMIZATION_COLOR = f"{Fore.WHITE}{Back.YELLOW}"
+SECURITY_COLOR = f"{Fore.WHITE}{Back.RED}"
+CVE_COLOR = f"{Fore.RED}"
+OPTIMIZATION_LABEL = f"{OPTIMIZATION_COLOR}[Optimization]{Style.RESET_ALL}"
+SECURITY_LABEL = f"{SECURITY_COLOR}[Security]{Style.RESET_ALL}"
 
 
 def test_format_security_warning_with_cve_id():
@@ -22,7 +23,7 @@ def test_format_security_warning_with_cve_id():
         cve_id
     )
     assert warning == (
-        f"{SECURITY_LABEL}[{cve_id}] Line {lineno}: {msg}"
+        f"{SECURITY_LABEL}{CVE_COLOR}[{cve_id}]{Style.RESET_ALL} Line {lineno}: {msg}"
     )
 
 

--- a/tests/test_optimzation_checks.py
+++ b/tests/test_optimzation_checks.py
@@ -1,6 +1,6 @@
 import ast
 import pytest
-from colorama import Fore
+from colorama import Fore, Back, Style
 
 from pyward.rules.optimization_rules import (
     check_unused_imports,
@@ -18,8 +18,8 @@ from pyward.rules.optimization_rules import (
     run_all_optimization_checks,
 )
 
-OPTIMIZATION_COLOR = Fore.YELLOW
-OPTIMIZATION_LABEL = f"{OPTIMIZATION_COLOR}[Optimization]{Fore.RESET}"
+OPTIMIZATION_COLOR = f"{Fore.WHITE}{Back.YELLOW}"
+OPTIMIZATION_LABEL = f"{OPTIMIZATION_COLOR}[Optimization]{Style.RESET_ALL}"
 
 
 def test_check_unused_imports_single_unused():


### PR DESCRIPTION
change warning message style

-  optimization label style to Fore.WHITE and Back.YELLOW
- security label style to Fore.WHITE and Back.RED
- cve label style to Fore.RED

All tests pass and no new  test included.
Now output in powershell look like
![1749126240788](https://github.com/user-attachments/assets/b436cdfa-82b1-4b32-8166-408002a4a36c)
This PR relates to #1 
