### PR TITLE
feat: enhance weak hashing usage checks with usedforsecurity paramete, add tests

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -57,7 +57,7 @@ def corge():
 def grault():
     # === Security: weak hashing usage (should trigger weak-hash warnings) ===
     data = b"secret data"
-    h1 = hashlib.md5(data)    # <--- should trigger hashlib.md5 warning
+    h1 = hashlib.md5(data, usedforsecurity=True)    # <--- should trigger hashlib.md5 warning
     h2 = hashlib.sha1(data)   # <--- should trigger hashlib.sha1 warning
     h3 = hashlib.sha256(data) # <--- this is okay
     print(f"MD5: {h1.hexdigest()}")

--- a/pyward/analyzer.py
+++ b/pyward/analyzer.py
@@ -10,6 +10,7 @@ from pyward.rules.optimization_rules import (
 from pyward.rules.security_rules import (
     check_exec_eval_usage,
     check_python_json_logger_import,
+    check_weak_hashing_usage,
 )
 
 
@@ -51,6 +52,9 @@ def analyze_file(
 
         json_logger_issues = check_python_json_logger_import(tree)
         issues.extend(json_logger_issues)
+
+        weak_hashing_issues = check_weak_hashing_usage(tree)
+        issues.extend(weak_hashing_issues)
 
     # If verbose is requested but no issues found, add a placeholder message
     if verbose and not issues:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="pyward-cli",
-    version="0.1.2",
+    version="0.1.3",
     description="A CLI linter for Python that flags optimization and security issues",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_security_checks.py
+++ b/tests/test_security_checks.py
@@ -134,6 +134,29 @@ h3 = hashlib.sha256(b"secure")
     assert any("hashlib.sha1()" in msg and "Line 4" in msg for msg in issues)
 
 
+def test_weak_hashing_usage_detect_md5_with_used_for_security_eq_true():
+    source = """
+import hashlib
+h1 = hashlib.md5(b"data", usedforsecurity=True)
+"""
+    tree = _parse_source(source)
+    issues = check_weak_hashing_usage(tree)
+
+    # Should detect md5 (line 3) with usedforsecurity=True
+    assert len(issues) == 1
+    assert any("hashlib.md5()" in msg and "Line 3" in msg for msg in issues)
+
+
+def test_weak_hashing_usage_ignore_md5_with_used_for_security_eq_false():
+    source = """
+import hashlib
+h1 = hashlib.md5(b"data", usedforsecurity=False)
+"""
+    tree = _parse_source(source)
+    issues = check_weak_hashing_usage(tree)
+    assert len(issues) == 0
+
+
 def test_run_all_checks_includes_pickle_usage_warning():
     source = """
 import pickle


### PR DESCRIPTION
modify weak hashing usage check to ignore cases where usedforsecurity=True.
add tests where usedforsecurity parameter is used.
add `check_weak_hashing_usage` into analyzer.
udpate version to `0.1.3`.
now execute `pyward -v demo.py` produces
![1749193174148](https://github.com/user-attachments/assets/0ad26430-517d-4fbb-91b7-9dffed8ae7ee)
This PR relates to #4 
