### PR TITLE
feat:flag insecure usage of urllib / urllib3

### DIFF
--- a/pyward/cli.py
+++ b/pyward/cli.py
@@ -1,5 +1,3 @@
-# pyward/cli.py
-
 import argparse
 import sys
 from pyward.analyzer import analyze_file

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="pyward-cli",
-    version="0.1.3",
+    version="0.1.4",
     description="A CLI linter for Python that flags optimization and security issues",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Resolves #21 

- Add `check_url_open_usage` to flag unsanitized calls to:
  • urllib.request.urlopen(...)  
  • urllib3.PoolManager().request(...)
  with dynamic URLs, recommending hostname/IP validation and strict SSL.

- Integrate all security rules via `run_all_checks` entry point (no need to import checks individually).

- Update `analyzer.py` to call:
  • `run_all_optimization_checks(source)`  
  • `run_all_security_checks(tree)`  
  instead of manual per-rule invocations.

- Expand `tests/test_security_checks.py`:
  • Import and test `check_url_open_usage`.  
  • Add positive and negative URL-opening test cases.  
  • Ensure `run_all_checks` includes both URL and existing warnings.