### PR TITLE
Detected misuse of list.sort() assignment

### DIFF
--- a/pyward/rules/optimization_rules.py
+++ b/pyward/rules/optimization_rules.py
@@ -601,18 +601,10 @@ def check_list_build_then_copy(tree: ast.AST) -> List[str]:
 
 
 def check_sort_assignment(tree: ast.AST) -> List[str]:
-    """
-    Detect assignments where list.sort() is assigned to a variable, which will be None.
-    This is often a logical bug since list.sort() modifies the list in-place and returns None.
-    Suggest using sorted() when assignment is needed.
-    """
     issues = []
-
     class SortVisitor(ast.NodeVisitor):
         def visit_Assign(self, node: ast.Assign):
-            if (isinstance(node.value, ast.Call) and 
-                isinstance(node.value.func, ast.Attribute) and 
-                node.value.func.attr == "sort"):
+            if (isinstance(node.value, ast.Call) and isinstance(node.value.func, ast.Attribute) and node.value.func.attr == "sort"):
                 issues.append(
                     format_optimization_warning(
                         f"Assignment of list.sort() which returns None. "
@@ -621,7 +613,6 @@ def check_sort_assignment(tree: ast.AST) -> List[str]:
                     )
                 )
             self.generic_visit(node)
-
     SortVisitor().visit(tree)
     return issues
 
@@ -648,7 +639,7 @@ def run_all_optimization_checks(source_code: str) -> List[str]:
     issues.extend(check_range_len_pattern(tree))
     issues.extend(check_append_in_loop(tree))
     issues.extend(check_list_build_then_copy(tree))
-    issues.extend(check_sort_assignment(tree))  # Add the new check
+    issues.extend(check_sort_assignment(tree))  #new check
 
     # Advanced optimizations
     issues.extend(check_dict_comprehension(tree))

--- a/tests/test_optimzation_checks.py
+++ b/tests/test_optimzation_checks.py
@@ -290,7 +290,7 @@ def test_check_list_build_then_copy_not_detected():
 
 def test_check_sort_assignment_detected():
     source = (
-        "lst = [3, 1, 2]\n"
+        "lst = [43, 68, 34]\n"
         "x = lst.sort()\n"
     )
     tree = ast.parse(source)
@@ -303,7 +303,7 @@ def test_check_sort_assignment_detected():
 
 def test_check_sort_assignment_not_detected():
     source = (
-        "lst = [3, 1, 2]\n"
+        "lst = [43, 68, 34]\n"
         "lst.sort()\n"
         "x = sorted(lst)\n"
     )
@@ -342,7 +342,7 @@ def test_run_all_optimization_checks_combined():
         "for x in range(5):\n"
         "    temp.append(x)\n"
         "copy = temp[:]\n"
-        "nums = [3, 1, 2]\n"
+        "nums = [43, 68, 34]\n"
         "sorted_nums = nums.sort()\n"
     )
     issues = run_all_optimization_checks(source)


### PR DESCRIPTION
# Add detection for list.sort() assignment misuse

## Problem
Developers sometimes incorrectly try to assign the result of `list.sort()` to a variable, not realizing that the method sorts in-place and returns `None`. This leads to bugs where the assigned variable contains `None` instead of the sorted list.

## Solution
Added a new optimization check that detects and warns when `list.sort()` is assigned to a variable. The warning suggests using `sorted()` when a new sorted list is needed.

### Implementation Details
Added new function in `optimization_rules.py`:
```python
def check_sort_assignment(tree: ast.AST) -> List[str]:
```

### Detection Examples
❌ Incorrect usage that will be detected:
```python
numbers = [43, 68 , 34]
sorted_numbers = numbers.sort()  # Warning: Returns None!
```

✅ Suggested alternatives:
```python
# For in-place sorting:
numbers = [43, 68 , 34]
numbers.sort()

# For getting a new sorted list:
numbers = [43, 68 , 34]
sorted_numbers = sorted(numbers)
```

## Changes Made
- Added `check_sort_assignment` function in `optimization_rules.py`
- Added unit tests in `test_optimzation_checks.py`:
  - `test_check_sort_assignment_detected()`
  - `test_check_sort_assignment_not_detected()`
  - Updated `test_run_all_optimization_checks_combined()`
- Added check to `run_all_optimization_checks()`
