### PR TITLE
chore: Increase test coverage for analyzer.py and cli.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="pyward-cli",
-    version="0.1.4",
+    version="0.1.5",
     description="A CLI linter for Python that flags optimization and security issues",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,209 @@
+import pytest
+import tempfile
+import os
+from unittest.mock import patch
+from pyward.analyzer import analyze_file
+
+@pytest.fixture
+def temp_python_file():
+    """temporary Python file"""
+    temp_dir = tempfile.mkdtemp()
+    
+    def _create_file(content: str, filename: str = "test.py") -> str:
+        filepath = os.path.join(temp_dir, filename)
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(content)
+        return filepath
+    
+    yield _create_file
+
+    for filename in os.listdir(temp_dir):
+        os.remove(os.path.join(temp_dir, filename))
+    os.rmdir(temp_dir)
+
+@pytest.fixture
+def mock_rules():
+    """mock optimization and security rule checkers function."""
+    with patch('pyward.analyzer.run_all_optimization_checks') as mock_opt, \
+         patch('pyward.analyzer.run_all_security_checks') as mock_sec:
+        mock_opt.return_value = []
+        mock_sec.return_value = []
+        yield mock_opt, mock_sec
+
+def test_analyze_file_valid_python_file(temp_python_file, mock_rules):
+    """Test analyzing a valid Python file with no issues."""
+    content = "print('test')"
+    filepath = temp_python_file(content)
+    mock_opt, mock_sec = mock_rules
+    
+    issues = analyze_file(filepath)
+    
+    assert issues == []
+    mock_opt.assert_called_once()
+    mock_sec.assert_called_once()
+
+@pytest.mark.parametrize("run_optimization,run_security,expected_calls", [
+    (True, True, (1, 1)),    # Both enabled
+    (True, False, (1, 0)),   # Only optimization
+    (False, True, (0, 1)),   # Only security
+    (False, False, (0, 0)),  # Both disabled
+])
+def test_analyze_file_rule_combinations(temp_python_file, mock_rules, 
+                                       run_optimization, run_security, expected_calls):
+    """Test different combinations of optimization and security rule execution."""
+    content = "print('test')"
+    filepath = temp_python_file(content)
+    mock_opt, mock_sec = mock_rules
+    
+    analyze_file(filepath, run_optimization=run_optimization, run_security=run_security)
+    
+    assert mock_opt.call_count == expected_calls[0]
+    assert mock_sec.call_count == expected_calls[1]
+
+@pytest.mark.parametrize("verbose,has_issues,expected_verbose_message", [
+    (True, False, True),   # Verbose mode, no issues -> should show verbose message
+    (True, True, False),   # Verbose mode, has issues -> should not show verbose message
+    (False, False, False), # Not verbose, no issues -> should not show verbose message
+    (False, True, False),  # Not verbose, has issues -> should not show verbose message
+])
+def test_analyze_file_verbose_mode(temp_python_file, verbose, has_issues, expected_verbose_message):
+    """Test verbose mode behavior with different scenarios."""
+    content = "print('test')"
+    filepath = temp_python_file(content)
+    
+    issues_to_return = ["Line 1: Some issue"] if has_issues else []
+    
+    with patch('pyward.analyzer.run_all_optimization_checks', return_value=issues_to_return), \
+         patch('pyward.analyzer.run_all_security_checks', return_value=[]):
+        
+        issues = analyze_file(filepath, verbose=verbose)
+        
+    if expected_verbose_message:
+        assert len(issues) == 1
+        assert "Verbose: no issues found" in issues[0]
+    elif has_issues:
+        assert len(issues) == 1
+        assert "Some issue" in issues[0]
+    else:
+        assert len(issues) == 0
+
+
+def test_analyze_file_syntax_error(temp_python_file):
+    """Test analyzing a file with syntax errors."""
+    content = '''
+def invalid_syntax(
+    print("missing closing parenthesis")
+'''
+    filepath = temp_python_file(content)
+    
+    issues = analyze_file(filepath)
+    
+    assert len(issues) == 1
+    assert "SyntaxError" in issues[0]
+    assert filepath in issues[0]
+
+
+def test_analyze_file_nonexistent_file():
+    """Test analyzing a non-existent file."""
+    nonexistent_path = "/nonexistent/path/test.py"
+    
+    with pytest.raises(FileNotFoundError):
+        analyze_file(nonexistent_path)
+
+def test_analyze_file_encoding_error():
+    """Test analyzing a file with encoding issues."""
+    temp_dir = tempfile.mkdtemp()
+    filepath = os.path.join(temp_dir, "test_encoding.py")
+    
+    try:
+        # Create a file with invalid UTF-8 encoding
+        with open(filepath, "wb") as f:
+            f.write(b'\xff\xfe# This is not valid UTF-8\n')
+        
+        with pytest.raises(UnicodeDecodeError):
+            analyze_file(filepath)
+    finally:
+        os.remove(filepath)
+        os.rmdir(temp_dir)
+
+@pytest.mark.parametrize("exception_source,error_message", [
+    ("optimization", "Optimization error"),
+    ("security", "Security error"),
+])
+def test_analyze_file_rule_checker_exceptions(temp_python_file, exception_source, error_message):
+    """Test behavior when rule checkers raise exceptions."""
+    content = "import os"
+    filepath = temp_python_file(content)
+    
+    if exception_source == "optimization":
+        with patch('pyward.analyzer.run_all_optimization_checks', 
+                  side_effect=Exception(error_message)):
+            with pytest.raises(Exception, match=error_message):
+                analyze_file(filepath)
+    else:
+        with patch('pyward.analyzer.run_all_optimization_checks', return_value=[]), \
+             patch('pyward.analyzer.run_all_security_checks', 
+                  side_effect=Exception(error_message)):
+            with pytest.raises(Exception, match=error_message):
+                analyze_file(filepath)
+
+def test_analyze_file_mixed_issues(temp_python_file):
+    """Test analyzing a file with both optimization and security issues."""
+    content = '''
+import numpy
+exec("dangerous_code")
+'''
+    filepath = temp_python_file(content)
+    
+
+    issues = analyze_file(filepath)
+        
+    assert len(issues) == 2
+    assert any("numpy" in issue for issue in issues)
+    assert any("exec()" in issue for issue in issues)
+
+
+@pytest.mark.parametrize("file_extension", [".py", ".pyx", ".pyi"])
+def test_analyze_file_different_extensions(temp_python_file, file_extension):
+    """Test analyzing files with different Python-related extensions."""
+    content = "print('test')"
+    filepath = temp_python_file(content, f"test{file_extension}")
+    
+    issues = analyze_file(filepath)
+    
+    assert issues == []
+
+
+def test_analyze_file_source_code_passed_to_optimization_rules(temp_python_file):
+    """Test that source code (not AST) is passed to optimization rules."""
+    content = "print('test')"
+    filepath = temp_python_file(content)
+    
+    with patch('pyward.analyzer.run_all_optimization_checks') as mock_opt, \
+         patch('pyward.analyzer.run_all_security_checks', return_value=[]):
+        
+        analyze_file(filepath)
+        
+        # Verify that run_all_optimization_checks was called with source code string
+        mock_opt.assert_called_once()
+        args = mock_opt.call_args[0]
+        assert len(args) == 1
+        assert isinstance(args[0], str)
+        assert "print('test')" in args[0]
+
+def test_analyze_file_ast_passed_to_security_rules(temp_python_file):
+    """Test that AST (not source code) is passed to security rules."""
+    content = "print('test')"
+    filepath = temp_python_file(content)
+    
+    with patch('pyward.analyzer.run_all_optimization_checks', return_value=[]), \
+         patch('pyward.analyzer.run_all_security_checks') as mock_sec:
+        
+        analyze_file(filepath)
+        
+        # Verify that run_all_security_checks was called with AST
+        mock_sec.assert_called_once()
+        args = mock_sec.call_args[0]
+        assert len(args) == 1
+        # AST objects have specific attributes
+        assert hasattr(args[0], 'body')  # AST modules have a body attribute

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -4,206 +4,282 @@ import os
 from unittest.mock import patch
 from pyward.analyzer import analyze_file
 
+
 @pytest.fixture
 def temp_python_file():
     """temporary Python file"""
     temp_dir = tempfile.mkdtemp()
-    
+
     def _create_file(content: str, filename: str = "test.py") -> str:
         filepath = os.path.join(temp_dir, filename)
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
         return filepath
-    
+
     yield _create_file
 
     for filename in os.listdir(temp_dir):
         os.remove(os.path.join(temp_dir, filename))
     os.rmdir(temp_dir)
 
+
 @pytest.fixture
 def mock_rules():
     """mock optimization and security rule checkers function."""
-    with patch('pyward.analyzer.run_all_optimization_checks') as mock_opt, \
-         patch('pyward.analyzer.run_all_security_checks') as mock_sec:
+    with patch("pyward.analyzer.run_all_optimization_checks") as mock_opt, patch(
+        "pyward.analyzer.run_all_security_checks"
+    ) as mock_sec:
         mock_opt.return_value = []
         mock_sec.return_value = []
         yield mock_opt, mock_sec
 
-def test_analyze_file_valid_python_file(temp_python_file, mock_rules):
-    """Test analyzing a valid Python file with no issues."""
-    content = "print('test')"
-    filepath = temp_python_file(content)
-    mock_opt, mock_sec = mock_rules
-    
-    issues = analyze_file(filepath)
-    
-    assert issues == []
-    mock_opt.assert_called_once()
-    mock_sec.assert_called_once()
 
-@pytest.mark.parametrize("run_optimization,run_security,expected_calls", [
-    (True, True, (1, 1)),    # Both enabled
-    (True, False, (1, 0)),   # Only optimization
-    (False, True, (0, 1)),   # Only security
-    (False, False, (0, 0)),  # Both disabled
-])
-def test_analyze_file_rule_combinations(temp_python_file, mock_rules, 
-                                       run_optimization, run_security, expected_calls):
-    """Test different combinations of optimization and security rule execution."""
-    content = "print('test')"
-    filepath = temp_python_file(content)
-    mock_opt, mock_sec = mock_rules
-    
-    analyze_file(filepath, run_optimization=run_optimization, run_security=run_security)
-    
-    assert mock_opt.call_count == expected_calls[0]
-    assert mock_sec.call_count == expected_calls[1]
+class TestAnalyzerUnit:
+    def test_analyze_file_valid_python_file(self, temp_python_file, mock_rules):
+        content = "print('test')"
+        filepath = temp_python_file(content)
+        mock_opt, mock_sec = mock_rules
 
-@pytest.mark.parametrize("verbose,has_issues,expected_verbose_message", [
-    (True, False, True),   # Verbose mode, no issues -> should show verbose message
-    (True, True, False),   # Verbose mode, has issues -> should not show verbose message
-    (False, False, False), # Not verbose, no issues -> should not show verbose message
-    (False, True, False),  # Not verbose, has issues -> should not show verbose message
-])
-def test_analyze_file_verbose_mode(temp_python_file, verbose, has_issues, expected_verbose_message):
-    """Test verbose mode behavior with different scenarios."""
-    content = "print('test')"
-    filepath = temp_python_file(content)
-    
-    issues_to_return = ["Line 1: Some issue"] if has_issues else []
-    
-    with patch('pyward.analyzer.run_all_optimization_checks', return_value=issues_to_return), \
-         patch('pyward.analyzer.run_all_security_checks', return_value=[]):
-        
-        issues = analyze_file(filepath, verbose=verbose)
-        
-    if expected_verbose_message:
-        assert len(issues) == 1
-        assert "Verbose: no issues found" in issues[0]
-    elif has_issues:
-        assert len(issues) == 1
-        assert "Some issue" in issues[0]
-    else:
-        assert len(issues) == 0
+        issues = analyze_file(filepath)
 
-
-def test_analyze_file_syntax_error(temp_python_file):
-    """Test analyzing a file with syntax errors."""
-    content = '''
-def invalid_syntax(
-    print("missing closing parenthesis")
-'''
-    filepath = temp_python_file(content)
-    
-    issues = analyze_file(filepath)
-    
-    assert len(issues) == 1
-    assert "SyntaxError" in issues[0]
-    assert filepath in issues[0]
-
-
-def test_analyze_file_nonexistent_file():
-    """Test analyzing a non-existent file."""
-    nonexistent_path = "/nonexistent/path/test.py"
-    
-    with pytest.raises(FileNotFoundError):
-        analyze_file(nonexistent_path)
-
-def test_analyze_file_encoding_error():
-    """Test analyzing a file with encoding issues."""
-    temp_dir = tempfile.mkdtemp()
-    filepath = os.path.join(temp_dir, "test_encoding.py")
-    
-    try:
-        # Create a file with invalid UTF-8 encoding
-        with open(filepath, "wb") as f:
-            f.write(b'\xff\xfe# This is not valid UTF-8\n')
-        
-        with pytest.raises(UnicodeDecodeError):
-            analyze_file(filepath)
-    finally:
-        os.remove(filepath)
-        os.rmdir(temp_dir)
-
-@pytest.mark.parametrize("exception_source,error_message", [
-    ("optimization", "Optimization error"),
-    ("security", "Security error"),
-])
-def test_analyze_file_rule_checker_exceptions(temp_python_file, exception_source, error_message):
-    """Test behavior when rule checkers raise exceptions."""
-    content = "import os"
-    filepath = temp_python_file(content)
-    
-    if exception_source == "optimization":
-        with patch('pyward.analyzer.run_all_optimization_checks', 
-                  side_effect=Exception(error_message)):
-            with pytest.raises(Exception, match=error_message):
-                analyze_file(filepath)
-    else:
-        with patch('pyward.analyzer.run_all_optimization_checks', return_value=[]), \
-             patch('pyward.analyzer.run_all_security_checks', 
-                  side_effect=Exception(error_message)):
-            with pytest.raises(Exception, match=error_message):
-                analyze_file(filepath)
-
-def test_analyze_file_mixed_issues(temp_python_file):
-    """Test analyzing a file with both optimization and security issues."""
-    content = '''
-import numpy
-exec("dangerous_code")
-'''
-    filepath = temp_python_file(content)
-    
-
-    issues = analyze_file(filepath)
-        
-    assert len(issues) == 2
-    assert any("numpy" in issue for issue in issues)
-    assert any("exec()" in issue for issue in issues)
-
-
-@pytest.mark.parametrize("file_extension", [".py", ".pyx", ".pyi"])
-def test_analyze_file_different_extensions(temp_python_file, file_extension):
-    """Test analyzing files with different Python-related extensions."""
-    content = "print('test')"
-    filepath = temp_python_file(content, f"test{file_extension}")
-    
-    issues = analyze_file(filepath)
-    
-    assert issues == []
-
-
-def test_analyze_file_source_code_passed_to_optimization_rules(temp_python_file):
-    """Test that source code (not AST) is passed to optimization rules."""
-    content = "print('test')"
-    filepath = temp_python_file(content)
-    
-    with patch('pyward.analyzer.run_all_optimization_checks') as mock_opt, \
-         patch('pyward.analyzer.run_all_security_checks', return_value=[]):
-        
-        analyze_file(filepath)
-        
-        # Verify that run_all_optimization_checks was called with source code string
+        assert issues == []
         mock_opt.assert_called_once()
-        args = mock_opt.call_args[0]
-        assert len(args) == 1
-        assert isinstance(args[0], str)
-        assert "print('test')" in args[0]
-
-def test_analyze_file_ast_passed_to_security_rules(temp_python_file):
-    """Test that AST (not source code) is passed to security rules."""
-    content = "print('test')"
-    filepath = temp_python_file(content)
-    
-    with patch('pyward.analyzer.run_all_optimization_checks', return_value=[]), \
-         patch('pyward.analyzer.run_all_security_checks') as mock_sec:
-        
-        analyze_file(filepath)
-        
-        # Verify that run_all_security_checks was called with AST
         mock_sec.assert_called_once()
-        args = mock_sec.call_args[0]
-        assert len(args) == 1
-        # AST objects have specific attributes
-        assert hasattr(args[0], 'body')  # AST modules have a body attribute
+
+    @pytest.mark.parametrize(
+        "run_optimization,run_security,expected_calls",
+        [
+            (True, True, (1, 1)),  # Both enabled
+            (True, False, (1, 0)),  # Only optimization
+            (False, True, (0, 1)),  # Only security
+            (False, False, (0, 0)),  # Both disabled
+        ],
+    )
+    def test_analyze_file_rule_combinations(
+        self,
+        temp_python_file,
+        mock_rules,
+        run_optimization,
+        run_security,
+        expected_calls,
+    ):
+        content = "print('test')"
+        filepath = temp_python_file(content)
+        mock_opt, mock_sec = mock_rules
+
+        analyze_file(
+            filepath, run_optimization=run_optimization, run_security=run_security
+        )
+
+        assert mock_opt.call_count == expected_calls[0]
+        assert mock_sec.call_count == expected_calls[1]
+
+    @pytest.mark.parametrize(
+        "verbose,has_issues,expected_verbose_message",
+        [
+            (
+                True,
+                False,
+                True,
+            ),  # Verbose mode, no issues -> should show verbose message
+            (
+                True,
+                True,
+                False,
+            ),  # Verbose mode, has issues -> should not show verbose message
+            (
+                False,
+                False,
+                False,
+            ),  # Not verbose, no issues -> should not show verbose message
+            (
+                False,
+                True,
+                False,
+            ),  # Not verbose, has issues -> should not show verbose message
+        ],
+    )
+    def test_analyze_file_verbose_mode(
+        self, temp_python_file, verbose, has_issues, expected_verbose_message
+    ):
+        content = "print('test')"
+        filepath = temp_python_file(content)
+
+        issues_to_return = ["Line 1: Some issue"] if has_issues else []
+
+        with patch(
+            "pyward.analyzer.run_all_optimization_checks", return_value=issues_to_return
+        ), patch("pyward.analyzer.run_all_security_checks", return_value=[]):
+
+            issues = analyze_file(filepath, verbose=verbose)
+
+        if expected_verbose_message:
+            assert len(issues) == 1
+            assert "Verbose: no issues found" in issues[0]
+        elif has_issues:
+            assert len(issues) == 1
+            assert "Some issue" in issues[0]
+        else:
+            assert len(issues) == 0
+
+    def test_analyze_file_syntax_error(self, temp_python_file):
+        content = "def invalid_syntax(\n" '   print("missing closing parenthesis")\n'
+        filepath = temp_python_file(content)
+
+        issues = analyze_file(filepath)
+
+        assert len(issues) == 1
+        assert "SyntaxError" in issues[0]
+        assert filepath in issues[0]
+
+    def test_analyze_file_nonexistent_file(self):
+        nonexistent_path = "/nonexistent/path/test.py"
+
+        with pytest.raises(FileNotFoundError):
+            analyze_file(nonexistent_path)
+
+    def test_analyze_file_empty_file(self, temp_python_file):
+        filepath = temp_python_file("")
+
+        issues = analyze_file(filepath)
+
+        assert issues == []
+
+    @pytest.mark.parametrize(
+        "exception_source,error_message",
+        [
+            ("optimization", "Optimization error"),
+            ("security", "Security error"),
+        ],
+    )
+    def test_analyze_file_rule_checker_exceptions(
+        self, temp_python_file, exception_source, error_message
+    ):
+        content = "import os"
+        filepath = temp_python_file(content)
+
+        if exception_source == "optimization":
+            with patch(
+                "pyward.analyzer.run_all_optimization_checks",
+                side_effect=Exception(error_message),
+            ), patch("pyward.analyzer.run_all_security_checks", return_value=[]):
+                with pytest.raises(Exception, match=error_message):
+                    analyze_file(filepath)
+        else:
+            with patch(
+                "pyward.analyzer.run_all_optimization_checks", return_value=[]
+            ), patch(
+                "pyward.analyzer.run_all_security_checks",
+                side_effect=Exception(error_message),
+            ):
+                with pytest.raises(Exception, match=error_message):
+                    analyze_file(filepath)
+
+    def test_analyze_file_source_code_passed_to_optimization_rules(
+        self, temp_python_file
+    ):
+        content = "print('test')"
+        filepath = temp_python_file(content)
+
+        with patch("pyward.analyzer.run_all_optimization_checks") as mock_opt, patch(
+            "pyward.analyzer.run_all_security_checks", return_value=[]
+        ):
+
+            analyze_file(filepath)
+
+            # Verify that run_all_optimization_checks was called with source code string
+            mock_opt.assert_called_once()
+            args = mock_opt.call_args[0]
+            assert len(args) == 1
+            assert isinstance(args[0], str)
+            assert "print('test')" in args[0]
+
+    def test_analyze_file_ast_passed_to_security_rules(self, temp_python_file):
+        content = "print('test')"
+        filepath = temp_python_file(content)
+
+        with patch(
+            "pyward.analyzer.run_all_optimization_checks", return_value=[]
+        ), patch("pyward.analyzer.run_all_security_checks") as mock_sec:
+
+            analyze_file(filepath)
+
+            # Verify that run_all_security_checks was called with AST
+            mock_sec.assert_called_once()
+            args = mock_sec.call_args[0]
+            assert len(args) == 1
+            # AST objects have specific attributes
+            assert hasattr(args[0], "body")  # AST modules have a body attribute
+
+
+class TestAnalyzerIntegration:
+    def test_analyze_file_mixed_issues(self, temp_python_file):
+        content = "import numpy\n" 'exec("dangerous_code")\n'
+        filepath = temp_python_file(content)
+        issues = analyze_file(filepath)
+
+        assert len(issues) == 2
+        assert any("numpy" in issue for issue in issues)
+        assert any("exec()" in issue for issue in issues)
+
+    def test_all_flow(self, temp_python_file):
+        content = (
+            "import os\n"
+            "import sys\n"
+            "x = 1\n"
+            "y = 2\n"
+            "def foo():\n"
+            "    return 3\n"
+            "    z = 4\n"
+            "for i in range(len([1, 2])):\n"
+            "    s = ''\n"
+            "    s = s + 'a'\n"
+            "    lst = []\n"
+            "    lst.append(i)\n"
+            "d = {}\n"
+            "for k, v in [('a', 1)]:\n"
+            "    d[k] = v\n"
+            "s2 = set()\n"
+            "for x in [1, 2]:\n"
+            "    s2.add(x)\n"
+            "total = sum([x for x in [1, 2, 3]])\n"
+            "lst2 = [1, 2, 3]\n"
+            "for x in [1, 4]:\n"
+            "    if x in lst2:\n"
+            "        pass\n"
+            "f = open('file.txt')\n"
+            "temp = []\n"
+            "for x in range(5):\n"
+            "    temp.append(x)\n"
+            "copy = temp[:]\n"
+        )
+        content += (
+            "import pickle\n"
+            'pickle.loads(b"abc")\n'
+            "import urllib.request\n"
+            "url = input()\n"
+            "urllib.request.urlopen(url)\n"
+        )
+        filepath = temp_python_file(content)
+        issues = analyze_file(filepath)
+
+        expected_substrings = [
+            "Imported name 'sys' is never used",
+            "Variable 'y' is assigned but never used",
+            "Line 7: This code is unreachable",
+            "Loop over 'range(len(...))'",
+            "String concatenation in loop for 's'",
+            "Using list.append() inside a loop",
+            "Building dict 'd' via loop assignment",
+            "Building set 's2' via add() in a loop",
+            "sum() applied to a list comprehension",
+            "Membership test 'x in lst2' inside a loop",
+            "Use of open() outside of a 'with' context manager",
+            "List 'temp' is built via append and then copied with slice",
+            "pickle.loads()",
+            "urlopen",
+        ]
+        for substring in expected_substrings:
+            assert any(
+                substring in msg for msg in issues
+            ), f"Missing issue containing: {substring}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,17 +7,18 @@ from unittest.mock import patch
 from io import StringIO
 from pyward.cli import main
 
+
 @pytest.fixture
 def temp_python_file():
     """Fixture to create a temporary Python file for CLI testing."""
     temp_dir = tempfile.mkdtemp()
     temp_file = os.path.join(temp_dir, "test.py")
-    
+
     with open(temp_file, "w", encoding="utf-8") as f:
         f.write("print('Hello, World!')\n")
-    
+
     yield temp_file
-    
+
     # Cleanup
     os.remove(temp_file)
     os.rmdir(temp_dir)
@@ -26,7 +27,7 @@ def temp_python_file():
 @pytest.fixture
 def mock_analyze_file():
     """Fixture to mock the analyze_file function."""
-    with patch('pyward.cli.analyze_file') as mock:
+    with patch("pyward.cli.analyze_file") as mock:
         yield mock
 
 
@@ -34,38 +35,35 @@ class TestCLIMain:
     """Test cases for the main CLI function."""
 
     def test_main_no_issues_found(self, temp_python_file, mock_analyze_file):
-        """Test main function when no issues are found."""
         mock_analyze_file.return_value = []
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
-            run_optimization=True,
-            run_security=True,
-            verbose=False
+            temp_python_file, run_optimization=True, run_security=True, verbose=False
         )
-        
+
         output = fake_stdout.getvalue()
         assert "✅ No issues found" in output
         assert temp_python_file in output
         assert exc_info.value.code == 0
 
     def test_main_with_issues_found(self, temp_python_file, mock_analyze_file):
-        """Test main function when issues are found."""
         mock_analyze_file.return_value = [
             "Line 1: Imported name 'os' is never used.",
-            "Line 5: Use of exec() detected."
+            "Line 5: Use of exec() detected.",
         ]
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert "❌ Found 2 issue(s)" in output
         assert temp_python_file in output
@@ -73,107 +71,121 @@ class TestCLIMain:
         assert "2. Line 5: Use of exec()" in output
         assert exc_info.value.code == 1
 
-    @pytest.mark.parametrize("flag,expected_opt,expected_sec", [
-        (['-o'], True, False),              # Optimization only
-        (['--optimize'], True, False),      # Optimization only (long form)
-        (['-s'], False, True),              # Security only
-        (['--security'], False, True),      # Security only (long form)
-        ([], True, True),                   # Default behavior (both)
-    ])
-    def test_main_flag_combinations(self, temp_python_file, mock_analyze_file,
-                                   flag, expected_opt, expected_sec):
-        """Test different flag combinations for optimization and security checks."""
+    @pytest.mark.parametrize(
+        "flag,expected_opt,expected_sec",
+        [
+            (["-o"], True, False),  # Optimization only
+            (["--optimize"], True, False),  # Optimization only (long form)
+            (["-s"], False, True),  # Security only
+            (["--security"], False, True),  # Security only (long form)
+            ([], True, True),  # Default behavior (both)
+        ],
+    )
+    def test_main_flag_combinations(
+        self, temp_python_file, mock_analyze_file, flag, expected_opt, expected_sec
+    ):
         mock_analyze_file.return_value = []
-        
-        argv = ['pyward'] + flag + [temp_python_file]
-        
-        with patch('sys.argv', argv), \
-             patch('sys.stdout', new=StringIO()):
+
+        argv = ["pyward"] + flag + [temp_python_file]
+
+        with patch("sys.argv", argv), patch("sys.stdout", new=StringIO()):
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         mock_analyze_file.assert_called_once_with(
             temp_python_file,
             run_optimization=expected_opt,
             run_security=expected_sec,
-            verbose=False
+            verbose=False,
         )
         assert exc_info.value.code == 0
 
-    @pytest.mark.parametrize("verbose_flag", ['-v', '--verbose'])
+    @pytest.mark.parametrize("verbose_flag", ["-v", "--verbose"])
     def test_main_verbose_flag(self, temp_python_file, mock_analyze_file, verbose_flag):
-        """Test main function with verbose flags."""
-        mock_analyze_file.return_value = ["Verbose: no issues found, but checks were performed."]
-        
-        with patch('sys.argv', ['pyward', verbose_flag, temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+        mock_analyze_file.return_value = [
+            "Verbose: no issues found, but checks were performed."
+        ]
+
+        with patch("sys.argv", ["pyward", verbose_flag, temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
-            run_optimization=True,
-            run_security=True,
-            verbose=True
+            temp_python_file, run_optimization=True, run_security=True, verbose=True
         )
-        
+
         output = fake_stdout.getvalue()
         assert "❌ Found 1 issue(s)" in output
         assert "Verbose: no issues found" in output
         assert exc_info.value.code == 1
 
-    def test_main_combined_flags(self, temp_python_file, mock_analyze_file):
-        """Test main function with combined flags."""
+    def test_main_combined_optimization_flags(
+        self, temp_python_file, mock_analyze_file
+    ):
         mock_analyze_file.return_value = []
-        
-        with patch('sys.argv', ['pyward', '-o', '-v', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()):
+
+        with patch("sys.argv", ["pyward", "-o", "-v", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
-            run_optimization=True,
-            run_security=False,
-            verbose=True
+            temp_python_file, run_optimization=True, run_security=False, verbose=True
+        )
+        assert exc_info.value.code == 0
+
+    def test_main_combined_security_flags(self, temp_python_file, mock_analyze_file):
+        mock_analyze_file.return_value = []
+
+        with patch("sys.argv", ["pyward", "-s", "-v", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file, run_optimization=False, run_security=True, verbose=True
         )
         assert exc_info.value.code == 0
 
     def test_main_no_filepath_provided(self):
-        """Test main function when no filepath is provided."""
-        with patch('sys.argv', ['pyward']), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+        with patch("sys.argv", ["pyward"]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert exc_info.value.code == 1
         assert "usage:" in output
 
     def test_main_file_not_found_error(self, mock_analyze_file):
-        """Test main function when file doesn't exist."""
         nonexistent_file = "/nonexistent/path/test.py"
         mock_analyze_file.side_effect = FileNotFoundError()
-        
-        with patch('sys.argv', ['pyward', nonexistent_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", nonexistent_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert "Error: File" in output
         assert "does not exist" in output
         assert exc_info.value.code == 1
 
     def test_main_general_exception(self, temp_python_file, mock_analyze_file):
-        """Test main function when analyze_file raises a general exception."""
         mock_analyze_file.side_effect = Exception("Something went wrong")
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert "Error analyzing" in output
         assert temp_python_file in output
@@ -181,188 +193,214 @@ class TestCLIMain:
         assert exc_info.value.code == 1
 
     def test_main_help_flag(self):
-        """Test main function with -h/--help flag."""
-        with patch('sys.argv', ['pyward', '-h']), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+        with patch("sys.argv", ["pyward", "-h"]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert "PyWard: CLI linter for Python" in output
         assert "optimization + security checks" in output
         assert exc_info.value.code == 0
 
     def test_main_mutually_exclusive_flags_error(self, temp_python_file):
-        """Test main function with mutually exclusive flags."""
-        with patch('sys.argv', ['pyward', '-o', '-s', temp_python_file]), \
-             patch('sys.stderr', new=StringIO()) as fake_stderr:
+        with patch("sys.argv", ["pyward", "-o", "-s", temp_python_file]), patch(
+            "sys.stderr", new=StringIO()
+        ) as fake_stderr:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
             # argparse should exit with error code 2 for invalid arguments
             assert exc_info.value.code == 2
-            
+
         error_output = fake_stderr.getvalue()
         assert "not allowed" in error_output
 
     @pytest.mark.parametrize("issues_count", [1, 5, 25, 50, 100])
-    def test_main_large_number_of_issues(self, temp_python_file, mock_analyze_file, 
-                                        issues_count):
+    def test_main_large_number_of_issues(
+        self, temp_python_file, mock_analyze_file, issues_count
+    ):
         """Test main function with varying numbers of issues."""
-        issues = [f"Line {i}: Mock issue number {i}" for i in range(1, issues_count + 1)]
+        issues = [
+            f"Line {i}: Mock issue number {i}" for i in range(1, issues_count + 1)
+        ]
         mock_analyze_file.return_value = issues
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert f"❌ Found {issues_count} issue(s)" in output
-        assert f"{issues_count}. Line {issues_count}: Mock issue number {issues_count}" in output
-        
-        assert exc_info.value.code == 1
+        assert (
+            f"{issues_count}. Line {issues_count}: Mock issue number {issues_count}"
+            in output
+        )
 
-    def test_main_output_formatting(self, temp_python_file, mock_analyze_file):
-        """Test that main function formats output correctly."""
-        mock_analyze_file.return_value = [
-            "Optimization issue here",
-            "Security issue here"
-        ]
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            
-        output = fake_stdout.getvalue()
-        lines = output.strip().split('\n')
-        
-        # Check header line
-        assert any("❌ Found 2 issue(s)" in line for line in lines)
-        
-        # Check issue formatting
-        assert any("1. Optimization issue here" in line for line in lines)
-        assert any("2. Security issue here" in line for line in lines)
-        
         assert exc_info.value.code == 1
 
     def test_main_empty_issues_list(self, temp_python_file, mock_analyze_file):
-        """Test main function with empty issues list."""
         mock_analyze_file.return_value = []
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_stdout:
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         output = fake_stdout.getvalue()
         assert "✅ No issues found" in output
         assert exc_info.value.code == 0
 
-    def test_main_single_issue(self, temp_python_file, mock_analyze_file):
-        """Test main function with exactly one issue."""
-        mock_analyze_file.return_value = ["Line 5: Single issue found"]
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()) as fake_stdout:
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            
-        output = fake_stdout.getvalue()
-        assert "❌ Found 1 issue(s)" in output
-        assert "1. Line 5: Single issue found" in output
-        assert exc_info.value.code == 1
+    def test_cli_integration(self):
+        from pathlib import Path
 
-    def test_cli_module_execution(self):
-        """Test CLI module execution - covers the if __name__ == '__main__' entry point"""
-        
-        result = subprocess.run(
-            [sys.executable, '-m', 'pyward.cli', '--help'],
-            capture_output=True,
-            text=True,
-            timeout=10
+        content = (
+            "import os\n"
+            "import sys\n"
+            "x = 1\n"
+            "y = 2\n"
+            "def foo():\n"
+            "    return 3\n"
+            "    z = 4\n"
+            "for i in range(len([1, 2])):\n"
+            "    s = ''\n"
+            "    s = s + 'a'\n"
+            "    lst = []\n"
+            "    lst.append(i)\n"
+            "d = {}\n"
+            "for k, v in [('a', 1)]:\n"
+            "    d[k] = v\n"
+            "s2 = set()\n"
+            "for x in [1, 2]:\n"
+            "    s2.add(x)\n"
+            "total = sum([x for x in [1, 2, 3]])\n"
+            "lst2 = [1, 2, 3]\n"
+            "for x in [1, 4]:\n"
+            "    if x in lst2:\n"
+            "        pass\n"
+            "f = open('file.txt')\n"
+            "temp = []\n"
+            "for x in range(5):\n"
+            "    temp.append(x)\n"
+            "copy = temp[:]\n"
         )
-        
-        assert result.returncode == 0
-        assert "PyWard: CLI linter for Python" in result.stdout
+        content += (
+            "import pickle\n"
+            'pickle.loads(b"abc")\n'
+            "import urllib.request\n"
+            "url = input()\n"
+            "urllib.request.urlopen(url)\n"
+        )
+
+        temp_dir = tempfile.mkdtemp()
+        temp_file = os.path.join(temp_dir, "integration_test.py")
+        try:
+            with open(temp_file, "w", encoding="utf-8") as f:
+                f.write(content)
+
+            current_dir = Path(__file__).parent
+            project_root = current_dir.parent
+            cmd = [sys.executable, "-m", "pyward.cli", temp_file]
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(project_root)
+
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, cwd=project_root, env=env
+            )
+            output = result.stdout.lower()
+            assert result.returncode == 1
+            assert len(output) > 0
+            assert "issue" in output
+            count_optimization = len(
+                [line for line in output.split("\n") if "optimization" in line]
+            )
+            count_security = len(
+                [line for line in output.split("\n") if "security" in line]
+            )
+            assert count_optimization >= 18
+            assert count_security >= 2
+
+        finally:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
+            if os.path.exists(temp_dir):
+                os.rmdir(temp_dir)
+
 
 class TestCLIArgumentParsing:
     """Test cases for CLI argument parsing."""
 
     def test_argument_parser_configuration(self):
-        """Test that argument parser is configured correctly."""
         import argparse
-        
+
         # Create a parser similar to the one in main()
         parser = argparse.ArgumentParser(
             prog="pyward",
             description="PyWard: CLI linter for Python (optimization + security checks)",
         )
-        
+
         group = parser.add_mutually_exclusive_group()
         group.add_argument("-o", "--optimize", action="store_true")
         group.add_argument("-s", "--security", action="store_true")
         parser.add_argument("-v", "--verbose", action="store_true")
         parser.add_argument("filepath", nargs="?")
-        
+
         # Test valid argument combinations
-        args = parser.parse_args(['-o', 'test.py'])
+        args = parser.parse_args(["-o", "test.py"])
         assert args.optimize is True
         assert args.security is False
-        
-        args = parser.parse_args(['-s', 'test.py'])
+
+        args = parser.parse_args(["-s", "test.py"])
         assert args.optimize is False
         assert args.security is True
-        
-        args = parser.parse_args(['-v', 'test.py'])
+
+        args = parser.parse_args(["-v", "test.py"])
         assert args.verbose is True
 
-    @pytest.mark.parametrize("invalid_args", [
-        ['-o', '-s', 'test.py'],           # Mutually exclusive flags
-        ['--optimize', '--security', 'test.py'],  # Long form mutually exclusive
-    ])
+    @pytest.mark.parametrize(
+        "invalid_args",
+        [
+            ["-o", "-s", "test.py"],  # Mutually exclusive flags
+            ["--optimize", "--security", "test.py"],  # Long form mutually exclusive
+        ],
+    )
     def test_invalid_argument_combinations(self, invalid_args):
-        """Test that invalid argument combinations are rejected."""
-        with patch('sys.argv', ['pyward'] + invalid_args), \
-             patch('sys.stderr', new=StringIO()):
+        with patch("sys.argv", ["pyward"] + invalid_args), patch(
+            "sys.stderr", new=StringIO()
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 2
 
     def test_long_flag_names(self, temp_python_file, mock_analyze_file):
-        """Test main function with long flag names."""
         mock_analyze_file.return_value = []
-        
-        with patch('sys.argv', ['pyward', '--optimize', '--verbose', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()):
+
+        with patch(
+            "sys.argv", ["pyward", "--optimize", "--verbose", temp_python_file]
+        ), patch("sys.stdout", new=StringIO()):
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
-            run_optimization=True,
-            run_security=False,
-            verbose=True
+            temp_python_file, run_optimization=True, run_security=False, verbose=True
         )
         assert exc_info.value.code == 0
 
     def test_default_behavior(self, temp_python_file, mock_analyze_file):
-        """Test main function default behavior (both optimization and security enabled)."""
         mock_analyze_file.return_value = []
-        
-        with patch('sys.argv', ['pyward', temp_python_file]), \
-             patch('sys.stdout', new=StringIO()):
+
+        with patch("sys.argv", ["pyward", temp_python_file]), patch(
+            "sys.stdout", new=StringIO()
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
-            
+
         # Default should be both optimization and security enabled
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
-            run_optimization=True,
-            run_security=True,
-            verbose=False
+            temp_python_file, run_optimization=True, run_security=True, verbose=False
         )
         assert exc_info.value.code == 0
-
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,368 @@
+import pytest
+import tempfile
+import os
+import sys
+import subprocess
+from unittest.mock import patch
+from io import StringIO
+from pyward.cli import main
+
+@pytest.fixture
+def temp_python_file():
+    """Fixture to create a temporary Python file for CLI testing."""
+    temp_dir = tempfile.mkdtemp()
+    temp_file = os.path.join(temp_dir, "test.py")
+    
+    with open(temp_file, "w", encoding="utf-8") as f:
+        f.write("print('Hello, World!')\n")
+    
+    yield temp_file
+    
+    # Cleanup
+    os.remove(temp_file)
+    os.rmdir(temp_dir)
+
+
+@pytest.fixture
+def mock_analyze_file():
+    """Fixture to mock the analyze_file function."""
+    with patch('pyward.cli.analyze_file') as mock:
+        yield mock
+
+
+class TestCLIMain:
+    """Test cases for the main CLI function."""
+
+    def test_main_no_issues_found(self, temp_python_file, mock_analyze_file):
+        """Test main function when no issues are found."""
+        mock_analyze_file.return_value = []
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=True,
+            run_security=True,
+            verbose=False
+        )
+        
+        output = fake_stdout.getvalue()
+        assert "✅ No issues found" in output
+        assert temp_python_file in output
+        assert exc_info.value.code == 0
+
+    def test_main_with_issues_found(self, temp_python_file, mock_analyze_file):
+        """Test main function when issues are found."""
+        mock_analyze_file.return_value = [
+            "Line 1: Imported name 'os' is never used.",
+            "Line 5: Use of exec() detected."
+        ]
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "❌ Found 2 issue(s)" in output
+        assert temp_python_file in output
+        assert "1. Line 1: Imported name 'os'" in output
+        assert "2. Line 5: Use of exec()" in output
+        assert exc_info.value.code == 1
+
+    @pytest.mark.parametrize("flag,expected_opt,expected_sec", [
+        (['-o'], True, False),              # Optimization only
+        (['--optimize'], True, False),      # Optimization only (long form)
+        (['-s'], False, True),              # Security only
+        (['--security'], False, True),      # Security only (long form)
+        ([], True, True),                   # Default behavior (both)
+    ])
+    def test_main_flag_combinations(self, temp_python_file, mock_analyze_file,
+                                   flag, expected_opt, expected_sec):
+        """Test different flag combinations for optimization and security checks."""
+        mock_analyze_file.return_value = []
+        
+        argv = ['pyward'] + flag + [temp_python_file]
+        
+        with patch('sys.argv', argv), \
+             patch('sys.stdout', new=StringIO()):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=expected_opt,
+            run_security=expected_sec,
+            verbose=False
+        )
+        assert exc_info.value.code == 0
+
+    @pytest.mark.parametrize("verbose_flag", ['-v', '--verbose'])
+    def test_main_verbose_flag(self, temp_python_file, mock_analyze_file, verbose_flag):
+        """Test main function with verbose flags."""
+        mock_analyze_file.return_value = ["Verbose: no issues found, but checks were performed."]
+        
+        with patch('sys.argv', ['pyward', verbose_flag, temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=True,
+            run_security=True,
+            verbose=True
+        )
+        
+        output = fake_stdout.getvalue()
+        assert "❌ Found 1 issue(s)" in output
+        assert "Verbose: no issues found" in output
+        assert exc_info.value.code == 1
+
+    def test_main_combined_flags(self, temp_python_file, mock_analyze_file):
+        """Test main function with combined flags."""
+        mock_analyze_file.return_value = []
+        
+        with patch('sys.argv', ['pyward', '-o', '-v', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=True,
+            run_security=False,
+            verbose=True
+        )
+        assert exc_info.value.code == 0
+
+    def test_main_no_filepath_provided(self):
+        """Test main function when no filepath is provided."""
+        with patch('sys.argv', ['pyward']), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert exc_info.value.code == 1
+        assert "usage:" in output
+
+    def test_main_file_not_found_error(self, mock_analyze_file):
+        """Test main function when file doesn't exist."""
+        nonexistent_file = "/nonexistent/path/test.py"
+        mock_analyze_file.side_effect = FileNotFoundError()
+        
+        with patch('sys.argv', ['pyward', nonexistent_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "Error: File" in output
+        assert "does not exist" in output
+        assert exc_info.value.code == 1
+
+    def test_main_general_exception(self, temp_python_file, mock_analyze_file):
+        """Test main function when analyze_file raises a general exception."""
+        mock_analyze_file.side_effect = Exception("Something went wrong")
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "Error analyzing" in output
+        assert temp_python_file in output
+        assert "Something went wrong" in output
+        assert exc_info.value.code == 1
+
+    def test_main_help_flag(self):
+        """Test main function with -h/--help flag."""
+        with patch('sys.argv', ['pyward', '-h']), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "PyWard: CLI linter for Python" in output
+        assert "optimization + security checks" in output
+        assert exc_info.value.code == 0
+
+    def test_main_mutually_exclusive_flags_error(self, temp_python_file):
+        """Test main function with mutually exclusive flags."""
+        with patch('sys.argv', ['pyward', '-o', '-s', temp_python_file]), \
+             patch('sys.stderr', new=StringIO()) as fake_stderr:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+            # argparse should exit with error code 2 for invalid arguments
+            assert exc_info.value.code == 2
+            
+        error_output = fake_stderr.getvalue()
+        assert "not allowed" in error_output
+
+    @pytest.mark.parametrize("issues_count", [1, 5, 25, 50, 100])
+    def test_main_large_number_of_issues(self, temp_python_file, mock_analyze_file, 
+                                        issues_count):
+        """Test main function with varying numbers of issues."""
+        issues = [f"Line {i}: Mock issue number {i}" for i in range(1, issues_count + 1)]
+        mock_analyze_file.return_value = issues
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert f"❌ Found {issues_count} issue(s)" in output
+        assert f"{issues_count}. Line {issues_count}: Mock issue number {issues_count}" in output
+        
+        assert exc_info.value.code == 1
+
+    def test_main_output_formatting(self, temp_python_file, mock_analyze_file):
+        """Test that main function formats output correctly."""
+        mock_analyze_file.return_value = [
+            "Optimization issue here",
+            "Security issue here"
+        ]
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        lines = output.strip().split('\n')
+        
+        # Check header line
+        assert any("❌ Found 2 issue(s)" in line for line in lines)
+        
+        # Check issue formatting
+        assert any("1. Optimization issue here" in line for line in lines)
+        assert any("2. Security issue here" in line for line in lines)
+        
+        assert exc_info.value.code == 1
+
+    def test_main_empty_issues_list(self, temp_python_file, mock_analyze_file):
+        """Test main function with empty issues list."""
+        mock_analyze_file.return_value = []
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "✅ No issues found" in output
+        assert exc_info.value.code == 0
+
+    def test_main_single_issue(self, temp_python_file, mock_analyze_file):
+        """Test main function with exactly one issue."""
+        mock_analyze_file.return_value = ["Line 5: Single issue found"]
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()) as fake_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        output = fake_stdout.getvalue()
+        assert "❌ Found 1 issue(s)" in output
+        assert "1. Line 5: Single issue found" in output
+        assert exc_info.value.code == 1
+
+    def test_cli_module_execution(self):
+        """Test CLI module execution - covers the if __name__ == '__main__' entry point"""
+        
+        result = subprocess.run(
+            [sys.executable, '-m', 'pyward.cli', '--help'],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        assert result.returncode == 0
+        assert "PyWard: CLI linter for Python" in result.stdout
+
+class TestCLIArgumentParsing:
+    """Test cases for CLI argument parsing."""
+
+    def test_argument_parser_configuration(self):
+        """Test that argument parser is configured correctly."""
+        import argparse
+        
+        # Create a parser similar to the one in main()
+        parser = argparse.ArgumentParser(
+            prog="pyward",
+            description="PyWard: CLI linter for Python (optimization + security checks)",
+        )
+        
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument("-o", "--optimize", action="store_true")
+        group.add_argument("-s", "--security", action="store_true")
+        parser.add_argument("-v", "--verbose", action="store_true")
+        parser.add_argument("filepath", nargs="?")
+        
+        # Test valid argument combinations
+        args = parser.parse_args(['-o', 'test.py'])
+        assert args.optimize is True
+        assert args.security is False
+        
+        args = parser.parse_args(['-s', 'test.py'])
+        assert args.optimize is False
+        assert args.security is True
+        
+        args = parser.parse_args(['-v', 'test.py'])
+        assert args.verbose is True
+
+    @pytest.mark.parametrize("invalid_args", [
+        ['-o', '-s', 'test.py'],           # Mutually exclusive flags
+        ['--optimize', '--security', 'test.py'],  # Long form mutually exclusive
+    ])
+    def test_invalid_argument_combinations(self, invalid_args):
+        """Test that invalid argument combinations are rejected."""
+        with patch('sys.argv', ['pyward'] + invalid_args), \
+             patch('sys.stderr', new=StringIO()):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
+
+    def test_long_flag_names(self, temp_python_file, mock_analyze_file):
+        """Test main function with long flag names."""
+        mock_analyze_file.return_value = []
+        
+        with patch('sys.argv', ['pyward', '--optimize', '--verbose', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=True,
+            run_security=False,
+            verbose=True
+        )
+        assert exc_info.value.code == 0
+
+    def test_default_behavior(self, temp_python_file, mock_analyze_file):
+        """Test main function default behavior (both optimization and security enabled)."""
+        mock_analyze_file.return_value = []
+        
+        with patch('sys.argv', ['pyward', temp_python_file]), \
+             patch('sys.stdout', new=StringIO()):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            
+        # Default should be both optimization and security enabled
+        mock_analyze_file.assert_called_once_with(
+            temp_python_file,
+            run_optimization=True,
+            run_security=True,
+            verbose=False
+        )
+        assert exc_info.value.code == 0
+
+


### PR DESCRIPTION
Resolves #27 
### Description
Added new test files (tests/test_analyzer.py, tests/test_cli.py) to increase test coverage for pyward/analyzer.py and pyward/cli.py. This boosts both files' coverage to 100%. Total test count reached 86, and all existing tests still pass.

### Changes
* Added `test_analyzer.py` - Tests for `pyward/analyzer.py`
* Added `test_cli.py` - Tests for `pyward/cli.py`
* `analyzer.py`→ 100% coverage, `cli.py` → 100% coverage
* Overall test count:→ 86


