### PR TITLE
Added security rule to detect disabled SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ PyWard is a lightweight command-line linter for Python code. It helps developers
 - **Security Checks**
   - Flags usage of `eval()` and `exec()` (e.g., CVE-2025-3248)
   - Detects vulnerable imports like `python_json_logger` (e.g., CVE-2025-27607)
+  - Identifies SSL verification being disabled (`verify=False`) in requests library calls
+  - Detects insecure subprocess usage with `shell=True`
 
 - **Flexible CLI**
   - Run all checks by default

--- a/tests/test_security_checks.py
+++ b/tests/test_security_checks.py
@@ -10,6 +10,7 @@ from pyward.rules.security_rules import (
     check_hardcoded_secrets,
     check_weak_hashing_usage,
     check_url_open_usage,
+    check_ssl_verification_disabled,
     run_all_checks,
 )
 
@@ -200,3 +201,17 @@ urllib.request.urlopen(url)
     assert any("pickle.loads()" in msg for msg in all_issues)
     assert any("urlopen" in msg for msg in all_issues)
     assert len(all_issues) >= 2
+
+
+def test_run_all_checks_includes_ssl_verification_warnings():
+    source = """
+import requests
+requests.get("https://example.com", verify=False)
+"""
+    tree = _parse_source(source)
+
+    all_issues = run_all_checks(tree)
+
+    assert any("verify=False" in msg for msg in all_issues)
+    assert any("requests.get()" in msg for msg in all_issues)
+    assert any("man-in-the-middle attacks" in msg for msg in all_issues)

--- a/tests/test_ssl_verification_disabled.py
+++ b/tests/test_ssl_verification_disabled.py
@@ -1,0 +1,65 @@
+import ast
+import pytest
+
+from pyward.rules.security_rules import check_ssl_verification_disabled
+
+
+def _parse_source(source: str) -> ast.AST:
+    return ast.parse(source)
+
+
+def test_requests_method_with_verify_false():
+    source = """
+import requests
+response = requests.get("https://example.com", verify=False)
+response = requests.post("https://example.com", data=data, verify=False)
+response = requests.put("https://api.example.com/resource", json=data, verify=False)
+"""
+    tree = _parse_source(source)
+    issues = check_ssl_verification_disabled(tree)
+
+    # We should have 3 issues, one for each requests method call
+    assert len(issues) == 3
+    assert any("requests.get()" in msg and "Line 3" in msg for msg in issues)
+    assert any("requests.post()" in msg and "Line 4" in msg for msg in issues)
+    assert any("requests.put()" in msg and "Line 5" in msg for msg in issues)
+
+
+def test_requests_generic_method_with_verify_false():
+    source = """
+import requests
+response = requests.request('GET', "https://example.com", verify=False)
+"""
+    tree = _parse_source(source)
+    issues = check_ssl_verification_disabled(tree)
+
+    # We should have 1 issue for the requests.request call
+    assert len(issues) == 1
+    assert "requests.request()" in issues[0]
+    assert "Line 3" in issues[0]
+
+
+def test_requests_session_method_with_verify_false():
+    source = """
+import requests
+session = requests.Session()
+response = session.get("https://example.com", verify=False)
+"""
+    tree = _parse_source(source)
+    issues = check_ssl_verification_disabled(tree)
+
+    assert len(issues) == 1
+    assert "verify=False" in issues[0]
+    assert "Line 4" in issues[0]
+
+
+def test_requests_methods_with_verify_true_or_omitted():
+    source = """
+import requests
+response = requests.get("https://example.com")  # Default is verify=True
+response = requests.post("https://example.com", data=data, verify=True)
+"""
+    tree = _parse_source(source)
+    issues = check_ssl_verification_disabled(tree)
+
+    assert len(issues) == 0  # No issues should be reported for these cases


### PR DESCRIPTION
# SSL Verification Security Rule

## Description
This PR adds a new security rule to detect instances where SSL verification is disabled in HTTP requests. When developers set `verify=False` in requests library calls, it exposes applications to man-in-the-middle attacks by skipping certificate verification.

## Implementation Details
- Added new rule `check_ssl_verification_disabled` in `security_rules.py` that detects three patterns:
  - Direct requests library methods: `requests.get/post/put/etc("url", verify=False)`
  - Generic request method: `requests.request("GET", "url", verify=False)`
  - Session objects with verify=False: `session.get("url", verify=False)`
- Added comprehensive tests in `tests/test_ssl_verification_disabled.py` 
- Updated security tests to include integration tests for the new rule
- Updated README.md to document the new security feature

## Security Impact
This rule will help developers identify and fix this security vulnerability by suggesting alternatives:
1. Enable SSL verification (default behavior)
2. Provide a custom CA bundle when dealing with self-signed certificates

Closes #20 