### PR TITLE
Add README.md to gh-pages branch to explain documentation site and update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here you'll find the latest docs built and published via GitHub Pages.
 
 ## 🔄 How to Update or Rebuild the Docs
 
-- The documentation is generated from source files and code in the [`main` branch](https://github.com/karanlvm/PyWard/tree/main) of this repository.
+- The documentation is generated from source files and code in the [main branch](https://github.com/karanlvm/PyWard/tree/main) of this repository.
 - To update or improve the documentation:
   1. **Edit source docs or code** in the `main` branch.
   2. **Follow the contributing guide** ([CONTRIBUTING.md](https://github.com/karanlvm/PyWard/blob/main/CONTRIBUTING.md)) for instructions on rebuilding and publishing docs.
@@ -42,7 +42,7 @@ Here you'll find the latest docs built and published via GitHub Pages.
 ## 📝 For Code, Issues, and Contributions
 
 - **Main CLI code, issues, and contributions:**  
-  [Go to the `main` branch →](https://github.com/karanlvm/PyWard/tree/main)
+  [Go to the main branch →](https://github.com/karanlvm/PyWard/tree/main)
 - **Contribute:**  
   See [CONTRIBUTING.md](https://github.com/karanlvm/PyWard/blob/main/CONTRIBUTING.md)
 
@@ -56,4 +56,4 @@ Here you'll find the latest docs built and published via GitHub Pages.
 
 ---
 
-> _This branch is dedicated only to the static documentation site. For development, issues, and source code, see the [`main`](https://github.com/karanlvm/PyWard/tree/main) branch._
+> _This branch is dedicated only to the static documentation site. For development, issues, and source code, see the [main](https://github.com/karanlvm/PyWard/tree/main) branch._

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# 📚 PyWard Documentation Site (`gh-pages` branch)
+
+Welcome!  
+This branch (`gh-pages`) is dedicated exclusively to hosting the **published documentation site** for [PyWard](https://github.com/karanlvm/PyWard) – a lightweight command-line linter for Python.  
+Here you'll find the latest docs built and published via GitHub Pages.
+
+---
+
+## 🌐 Live Documentation
+
+- **Visit the site:** [https://karanlvm.github.io/PyWard/](https://karanlvm.github.io/PyWard/)
+
+---
+
+## 🔄 How to Update or Rebuild the Docs
+
+- The documentation is generated from source files and code in the [`main` branch](https://github.com/karanlvm/PyWard/tree/main) of this repository.
+- To update or improve the documentation:
+  1. **Edit source docs or code** in the `main` branch.
+  2. **Follow the contributing guide** ([CONTRIBUTING.md](https://github.com/karanlvm/PyWard/blob/main/CONTRIBUTING.md)) for instructions on rebuilding and publishing docs.
+  3. When new docs are published, this branch will be updated automatically (or per the project's process).
+
+*Please do not edit files directly in `gh-pages` unless you are maintaining the published site.*
+
+---
+
+## 🛠️ About PyWard
+
+**PyWard** is a command-line linter for Python code that helps you catch optimization issues and security vulnerabilities before they become problems.  
+- **Install:**  
+  ```bash
+  pip install pyward-cli
+  ```
+- **Run:**  
+  ```bash
+  pyward <file_or_directory>
+  ```
+- See the [main repo](https://github.com/karanlvm/PyWard) for full usage examples and available checks.
+
+---
+
+## 📝 For Code, Issues, and Contributions
+
+- **Main CLI code, issues, and contributions:**  
+  [Go to the `main` branch →](https://github.com/karanlvm/PyWard/tree/main)
+- **Contribute:**  
+  See [CONTRIBUTING.md](https://github.com/karanlvm/PyWard/blob/main/CONTRIBUTING.md)
+
+---
+
+## ⭐ Useful Links
+
+- **PyPI:** [pyward-cli](https://pypi.org/project/pyward-cli/)
+- **License:** [MIT](https://github.com/karanlvm/PyWard/blob/main/LICENSE)
+- **Project Home:** [PyWard on GitHub](https://github.com/karanlvm/PyWard)
+
+---
+
+> _This branch is dedicated only to the static documentation site. For development, issues, and source code, see the [`main`](https://github.com/karanlvm/PyWard/tree/main) branch._


### PR DESCRIPTION
This pull request adds a comprehensive `README.md` to the root of the `gh-pages` branch.

**Summary of changes:**
- Introduces a README explaining the purpose of the `gh-pages` branch as the host for the live documentation site.
- Provides a direct link to the published documentation.
- Includes instructions and notes on how to update or rebuild the documentation, referencing the source files and contributing guide in the `main` branch.
- Links back to the main CLI repository for code, issues, and contributions.
- Details about PyWard, installation, and usage for context.

This README aims to help users and contributors understand the structure and update process for the documentation site, as well as direct them to the correct branch for code and contributions.