### PR TITLE
Feat/fix arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ MIT License — see [LICENSE](LICENSE).
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
         <a href=https://github.com/nayanaaj9>
-            <img src=https://avatars.githubusercontent.com/u/215096912?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Nayana/>
+            <img src=https://avatars.githubusercontent.com/u/215096912?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Nayana Jagadeesh/>
             <br />
-            <sub style="font-size:14px"><b>Nayana</b></sub>
+            <sub style="font-size:14px"><b>Nayana Jagadeesh</b></sub>
         </a>
     </td>
 </tr>

--- a/demo/optimization/unused_imports.py
+++ b/demo/optimization/unused_imports.py
@@ -1,7 +1,12 @@
 # triggers check_unused_imports
 import os
 import sys
-import json  # never used
+from typing import (
+    List,
+    Set,
+    Tuple,
+)
 
 def foo():
     print(os.getcwd())
+    s: Set = set([])

--- a/pyward/optimization/rules/unused_imports.py
+++ b/pyward/optimization/rules/unused_imports.py
@@ -35,11 +35,14 @@ def check_unused_imports(tree: ast.AST) -> List[str]:
     return issues
 
 
-def fix_unused_imports(source: str) -> Tuple[bool, str]:
+def fix_unused_imports(source: str) -> Tuple[bool, str, List[str]]:
     fixer = ImportFixer(source)
     if not fixer.unused_names_in_import:
-        return (False, source)
-    for name_and_import in fixer.unused_names_in_import:
-        msg = f"from {name_and_import[1].module} import {name_and_import[0]} deleted" if name_and_import[1].is_from else f"import {name_and_import[0]} deleted"
-        print(msg)
-    return (True, fixer.fix())
+        return (False, source, [])
+    
+    def get_msg(item):
+        return f"from {item[1].module} import {item[0]} deleted" \
+            if item[1].is_from else f"import {item[0]} deleted"
+
+    fixes = [get_msg(item) for item in fixer.unused_names_in_import]
+    return (True, fixer.fix(), fixes)

--- a/pyward/optimization/rules/unused_imports.py
+++ b/pyward/optimization/rules/unused_imports.py
@@ -1,6 +1,7 @@
 import ast
 from typing import List, Set, Tuple
 from pyward.format.formatter import format_optimization_warning
+from pyward.fixer.fix_imports import ImportFixer
 
 def check_unused_imports(tree: ast.AST) -> List[str]:
     issues: List[str] = []
@@ -32,3 +33,13 @@ def check_unused_imports(tree: ast.AST) -> List[str]:
                 )
             )
     return issues
+
+
+def fix_unused_imports(source: str) -> Tuple[bool, str]:
+    fixer = ImportFixer(source)
+    if not fixer.unused_names_in_import:
+        return (False, source)
+    for name_and_import in fixer.unused_names_in_import:
+        msg = f"from {name_and_import[1].module} import {name_and_import[0]} deleted" if name_and_import[1].is_from else f"import {name_and_import[0]} deleted"
+        print(msg)
+    return (True, fixer.fix())

--- a/pyward/optimization/run.py
+++ b/pyward/optimization/run.py
@@ -1,7 +1,8 @@
 import ast
 import pkgutil
 import importlib
-from typing import List
+from typing import List, Tuple
+from os import path
 
 def run_all_optimization_checks(source_code: str, skip: List[str] = None) -> List[str]:
     skip = set(skip or [])
@@ -16,7 +17,33 @@ def run_all_optimization_checks(source_code: str, skip: List[str] = None) -> Lis
             if not fn_name.startswith("check_") or fn_name in skip:
                 continue
             fn = getattr(mod, fn_name)
-            issues.extend(fn(tree))
+            if callable(fn):
+                issues.extend(fn(tree))
 
     return issues
+
+
+def run_all_optimization_fixes(source_code: str, skip: List[str] = None) -> Tuple[bool, str]:
+    """fix code with fixable optimization rules, add rule into skip list, return fix flag and fixed code"""
+    skip_set = set(skip or [])
+
+    pkg = importlib.import_module(f"{__package__}.rules")
+    prefix = pkg.__name__ + "."
+    current_source = source_code
+    file_ever_changed = False
+    for _, mod_name, _ in pkgutil.iter_modules(pkg.__path__, prefix):
+        mod = importlib.import_module(mod_name)
+        rule_name = path.basename(str(mod.__file__))[0:-3]
+        for fn_name in dir(mod):
+            fix_fn_name = "fix_" + rule_name
+            check_fn_name = "check_" + rule_name
+            if fn_name != fix_fn_name or check_fn_name in skip_set:
+                continue
+            fix_fn = getattr(mod, fix_fn_name)
+            if callable(fix_fn):
+                file_changed, current_source = fix_fn(source_code)
+                file_ever_changed = file_changed or file_ever_changed
+                skip.append(check_fn_name)
+
+    return (file_ever_changed, current_source)
 

--- a/pyward/security/run.py
+++ b/pyward/security/run.py
@@ -2,6 +2,7 @@ import ast
 import pkgutil
 import importlib
 from typing import List, Tuple
+from os import path
 
 def run_all_security_checks(
     source_code: str,
@@ -29,25 +30,27 @@ def run_all_security_checks(
     return issues
 
 
-def run_all_security_fixes(source_code: str, skip: List[str] = None) -> Tuple[bool, str]:
-    """fix code with fixable security rules, add rule into skip list, return fix flag and fixed code"""
+def run_all_security_fixes(source_code: str, skip: List[str] = None) -> Tuple[bool, str, List[str]]:
+    """fix code with fixable security rules, return fix flag and fixed code"""
     skip_set = set(skip or [])
 
     pkg = importlib.import_module(f"{__package__}.rules")
     prefix = pkg.__name__ + "."
     current_source = source_code
     file_ever_changed = False
+    all_fixes = []
     for _, mod_name, _ in pkgutil.iter_modules(pkg.__path__, prefix):
         mod = importlib.import_module(mod_name)
+        rule_name = path.basename(str(mod.__file__))[0:-3]
         for fn_name in dir(mod):
-            fix_fn_name = "fix_" + mod_name
-            check_fn_name = "check_" + mod_name
+            fix_fn_name = "fix_" + rule_name
+            check_fn_name = "check_" + rule_name
             if fn_name != fix_fn_name or check_fn_name in skip_set:
                 continue
             fix_fn = getattr(mod, fix_fn_name)
-            if callable(fix_fn_name):
-                file_changed, current_source = fix_fn(source_code)
+            if callable(fix_fn):
+                file_changed, current_source, fixes = fix_fn(source_code)
                 file_ever_changed = file_changed or file_ever_changed
-                skip.append(check_fn_name)
+                all_fixes.extend(fixes)
 
-    return (file_ever_changed, current_source)
+    return (file_ever_changed, current_source, all_fixes)

--- a/pyward/security/run.py
+++ b/pyward/security/run.py
@@ -1,7 +1,7 @@
 import ast
 import pkgutil
 import importlib
-from typing import List
+from typing import List, Tuple
 
 def run_all_security_checks(
     source_code: str,
@@ -27,3 +27,27 @@ def run_all_security_checks(
                 issues.extend(fn(tree))
 
     return issues
+
+
+def run_all_security_fixes(source_code: str, skip: List[str] = None) -> Tuple[bool, str]:
+    """fix code with fixable security rules, add rule into skip list, return fix flag and fixed code"""
+    skip_set = set(skip or [])
+
+    pkg = importlib.import_module(f"{__package__}.rules")
+    prefix = pkg.__name__ + "."
+    current_source = source_code
+    file_ever_changed = False
+    for _, mod_name, _ in pkgutil.iter_modules(pkg.__path__, prefix):
+        mod = importlib.import_module(mod_name)
+        for fn_name in dir(mod):
+            fix_fn_name = "fix_" + mod_name
+            check_fn_name = "check_" + mod_name
+            if fn_name != fix_fn_name or check_fn_name in skip_set:
+                continue
+            fix_fn = getattr(mod, fix_fn_name)
+            if callable(fix_fn_name):
+                file_changed, current_source = fix_fn(source_code)
+                file_ever_changed = file_changed or file_ever_changed
+                skip.append(check_fn_name)
+
+    return (file_ever_changed, current_source)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,14 +11,14 @@ from pathlib import Path
 # analyze_file(), and ArgumentParser1 classes.
 from pyward.cli import main
 
-
+FILE_CONTENT = "import os\n\nprint('Hello')\n"
 @pytest.fixture
 def temp_python_file():
     """Creates a temporary python file for testing."""
     d = tempfile.mkdtemp()
     path = os.path.join(d, "test.py")
     with open(path, "w") as f:
-        f.write("import os\n\nprint('Hello')\n")
+        f.write(FILE_CONTENT)
     yield path
     os.remove(path)
     os.rmdir(d)
@@ -41,7 +41,7 @@ class TestCLIMain:
                 main()
 
         mock_analyze_file.assert_called_once_with(
-            temp_python_file, run_optimization=True, run_security=True, skip_list=[]
+            source=FILE_CONTENT, run_optimization=True, run_security=True, skip_list=[]
         )
         assert "✅ No issues found" in out.getvalue()
         assert e.value.code == 0
@@ -77,7 +77,7 @@ class TestCLIMain:
                 main()
 
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
+            source=FILE_CONTENT,
             run_optimization=opt,
             run_security=sec,
             skip_list=[]
@@ -96,7 +96,7 @@ class TestCLIMain:
                 main()
 
         mock_analyze_file.assert_called_once_with(
-            temp_python_file,
+            source=FILE_CONTENT,
             run_optimization=True,
             run_security=True,
             skip_list=expected_list
@@ -148,10 +148,9 @@ class TestCLIMain:
         assert e.value.code == 2
         assert "not allowed with" in err.getvalue()
 
-    def test_file_not_found(self, mock_analyze_file):
+    def test_file_not_found(self):
         """Tests the error handling for a file that does not exist."""
-        mock_analyze_file.side_effect = FileNotFoundError("File 'nonexistent.py' not found")
-        with patch.object(sys, "argv", ["pyward", "/nonexistent.py"]), \
+        with patch.object(sys, "argv", ["pyward", "nonexistent.py"]), \
              patch("sys.stderr", new=StringIO()) as err:
             with pytest.raises(SystemExit) as e:
                 main()


### PR DESCRIPTION
implement #39 --fix architecture, the whole control flow now behaves like below:
1. iterate over file hierachy, for each file:
    1. test -f/--fix flag, if present, execute `fix_file`
        1. `fix_file` first check optimization rules with `fix_{rule_name}` function, invoke it
        2. `fix_{rule_name}` returns file_changed_flag, changed_file_content and fix_message list, **note:** no actual write to file yet
        3. next `fix_{rule_name}` function would use changed_file_content as input and add result into fix_message list
        4. then security rules with `fix_{rule_name}` function would be invoked
        5. when all fix functions are applied, check file_changed_flag, if set
            1. print fix messages
            2. save file
        6. `analyze_file` would then take changed_file_content as input

a snippet of execution of `pyward -r -f .\demo`

![1750259784881](https://github.com/user-attachments/assets/c4afe8f2-446f-44af-932a-b29e525d5217)

test file before
![1750259736083](https://github.com/user-attachments/assets/7f3f55c5-51e2-48a2-8b38-0235574b88fd)

test file after fix
![1750259797644](https://github.com/user-attachments/assets/db25f082-d5fb-41df-b07b-736948fafa54)

test for `fix_file` in cli.py is added, no test for `run.py` added because rule discovery logic would delegate to `rule_finder` in latest commits so refactoring is inevitable.
Any suggestion on architecture issues or output format or anything else is welcome! 